### PR TITLE
Create snackbar context and use it in authProvider

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,6 @@
     "@types/node": "^16.18.36",
     "@types/react": "^18.2.12",
     "@types/react-dom": "^18.2.5",
-    "antd": "^5.6.1",
     "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,12 +1,10 @@
-import {
-  Routes,
-  Route
-} from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
 
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 
 import { AuthProvider } from './context/AuthProvider';
+import SnackBarProvider from "./context/SnackBar";
 
 import LoginPage from "./pages/LoginPage"
 
@@ -20,31 +18,34 @@ import themeOptions from './theme/classical'
 
 import './App.css';
 
+
 const theme = createTheme(themeOptions)
 
 function App() {
   return (
-    <AuthProvider>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <Routes>
-          <Route element={<Layout />}>
-            <Route path="/" element={<PublicPage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/register" element={<RegisterPage />} />
-            <Route path="/reset_password" element={<ResetPasswordRequestPage />} />
-            <Route
-              path="/protected"
-              element={
-                <RequireAuth>
-                  <ProtectedPage />
-                </RequireAuth>
-              }
-            />
-          </Route>
-        </Routes>
-      </ThemeProvider>
-    </AuthProvider>
+    <SnackBarProvider>
+      <AuthProvider>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <Routes>
+            <Route element={<Layout />}>
+              <Route path="/" element={<PublicPage />} />
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/register" element={<RegisterPage />} />
+              <Route path="/reset_password" element={<ResetPasswordRequestPage />} />
+              <Route
+                path="/protected"
+                element={
+                  <RequireAuth>
+                    <ProtectedPage />
+                  </RequireAuth>
+                }
+              />
+            </Route>
+          </Routes>
+        </ThemeProvider>
+      </AuthProvider >
+    </SnackBarProvider >
   );
 }
 

--- a/client/src/context/AuthProvider.tsx
+++ b/client/src/context/AuthProvider.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { AxiosError, AxiosResponse } from "axios";
-import { message } from "antd";
 
 import { ErrorPayload } from '../../../comon_src/type/error.type'
 import { UserProfile } from "../../../comon_src/type/user.type";
 
 import fakeAuthProvider from "../services/fakeAuthProvider";
 import api from "../services/api";
+
+import { useSnackbar } from "./SnackBar";
 
 interface AuthContextType {
   user: any;
@@ -20,6 +21,7 @@ let AuthContext = React.createContext<AuthContextType>(null!);
 
 function AuthProvider({ children }: { children: React.ReactNode }) {
   let [user, setUser] = React.useState<UserProfile | null>(null);
+  const snackBar = useSnackbar();
 
   let signin = (username: string, password: string, callback: VoidFunction) => {
     api.signin(username, password)
@@ -34,7 +36,7 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
         // Update the user state
         setUser(profile);
 
-        message.success("Login successfull");
+        snackBar("Login successfull", 'success');
         callback();
       })
       .catch((error: AxiosError) => {
@@ -42,31 +44,31 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
         const errorMessage = (error.response?.data as ErrorPayload)?.error;
 
         // Display error message to the user
-        message.error('Login failed' + (errorMessage && (': ' + errorMessage)));
+        snackBar('Login failed' + (errorMessage && (': ' + errorMessage)), 'error');
       })
   };
 
   let signup = (username: string, email: string, firstName: string, lastName: string, password: string, callback: VoidFunction) => {
     api.signup(username, email, firstName, lastName, password)
       .then((res: AxiosResponse) => {
-        message.success('Registration successful. You can now login !');
+        snackBar('Registration successful. You can now login !', 'success');
         callback();
       })
       .catch((error: AxiosError) => {
         const errorMessage = (error.response?.data as ErrorPayload)?.error;
-        message.error('Registration failed' + (errorMessage ? ': ' + errorMessage : ''));
+        snackBar('Registration failed' + (errorMessage ? ': ' + errorMessage : ''), 'error');
       });
   };
 
   let resetPasswordRequest = (email: string, callback: VoidFunction) => {
     fakeAuthProvider.resetPasswordRequest(email)
       .then((res: any) => {
-        message.success('An email has been sent to ' + email + '. Clik in the link inside to reset your password');
+        snackBar('An email has been sent to ' + email + '. Clik in the link inside to reset your password', 'success');
         callback();
       })
       .catch((error: AxiosError) => {
         const errorMessage = (error.response?.data as ErrorPayload)?.error;
-        message.error('Registration failed' + (errorMessage ? ': ' + errorMessage : ''));
+        snackBar('Registration failed' + (errorMessage ? ': ' + errorMessage : ''), 'error');
       })
   }
 
@@ -78,12 +80,12 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
         // Update the user state
         setUser(null);
 
-        message.success("Logout successfull");
+        snackBar("Logout successfull", 'success');
         callback();
       })
       .catch((error: AxiosError) => {
         const errorMessage = (error.response?.data as ErrorPayload)?.error;
-        message.error('Logout failed' + (errorMessage ? ': ' + errorMessage : ''));
+        snackBar('Logout failed' + (errorMessage ? ': ' + errorMessage : ''), 'error');
       })
   };
 

--- a/client/src/context/SnackBar.tsx
+++ b/client/src/context/SnackBar.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useState, useCallback, useContext } from 'react';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+
+type SnackbarContextType = {
+  (message: string, severity: 'error' | 'warning' | 'info' | 'success'): void;
+};
+
+const SnackbarContext = createContext<SnackbarContextType>(() => {});
+
+function SnackBarProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<'error' | 'warning' | 'info' | 'success'>('success');
+
+  const openSnackbar: SnackbarContextType = useCallback((message, severity) => {
+    setMessage(message);
+    setSeverity(severity);
+    setOpen(true);
+  }, []);
+
+  const closeSnackbar = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  return (
+    <SnackbarContext.Provider value={openSnackbar}>
+      {children}
+      <Snackbar
+        open={open}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        autoHideDuration={6000}
+        onClose={closeSnackbar}
+        action={
+          <IconButton
+            size="small"
+            aria-label="close"
+            color="inherit"
+            onClick={closeSnackbar}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        }
+      >
+        <Alert onClose={closeSnackbar} severity={severity} variant="filled">
+          {message}
+        </Alert>
+      </Snackbar>
+    </SnackbarContext.Provider>
+  );
+};
+
+export const useSnackbar = () => {
+  return useContext(SnackbarContext);
+};
+
+export default SnackBarProvider;


### PR DESCRIPTION
Après être passé de antd à Material design pour la librairie de composants react, "message" était le dernier composant antd utilisé.

Cette PR utilise le composant snackbar de mui v5 pour remplacer le message de antd et ainsi pouvoir désinstaller antd complètement